### PR TITLE
Length control for connecting-line

### DIFF
--- a/components/connecting-line/README.md
+++ b/components/connecting-line/README.md
@@ -8,15 +8,17 @@ The position of the line is updated automatically whenever the entity at either 
 
 ## Schema
 
-| Property    | Description                                                  | Default |
-| ----------- | ------------------------------------------------------------ | ------- |
-| start       | selector for entity to draw line from                        |         |
-| startOffset | offset of the start of the line  in the co-ordinate space of the start entity | 0 0 0   |
-| end         | selector for entity to draw line to                          |         |
-| endOffset   | offset of the start of the line  in the co-ordinate space of the end entity | 0 0 0   |
-| color       | as per "line" component                                      | #74BEC1 |
-| opacity     | as per "line" component                                      | 1       |
-| visible     | as per "line" component                                      | true    |
+| Property              | Description                                                  | Default |
+| --------------------- | ------------------------------------------------------------ | ------- |
+| start                 | selector for entity to draw line from                        |         |
+| startOffset           | offset of the start of the line  in the co-ordinate space of the start entity | 0 0 0   |
+| end                   | selector for entity to draw line to                          |         |
+| endOffset             | offset of the start of the line  in the co-ordinate space of the end entity | 0 0 0   |
+| color                 | as per "line" component                                      | #74BEC1 |
+| opacity               | as per "line" component                                      | 1       |
+| visible               | as per "line" component                                      | true    |
+| lengthAdjustment      | one of: none, scale, extend, absolute                        | none    |
+| lengthAdjustmentValue | Value used in adjusting the length of the line.  Meaning depends on the lengthAdjustment parameter as follows:<br /><br />none: this parameter is ignored<br />scale: a scale factor to apply to the length of the connecting line, relative to the actual distance between start and end<br />extend: an absolute length to extend the connecting line by (negative values will mean the line is just short of the points)<br />absoute: an absolute length for the connecting line, irrespective of the distance between start and end. | 0       |
 
 
 

--- a/components/connecting-line/index.js
+++ b/components/connecting-line/index.js
@@ -7,7 +7,9 @@ AFRAME.registerComponent('connecting-line', {
         endOffset: {type: 'vec3', default:  {x: 0, y: 0, z: 0}},
         color: {type: 'color', default: '#74BEC1'},
         opacity: {type: 'number', default: 1},
-        visible: {default: true}
+        visible: {default: true},
+        lengthAdjustment: {default: "none", oneOf: ["none", "scale", "extend", "absolute"]},
+        lengthAdjustmentValue: {type: 'number'}
     },
 
     multiple: true,
@@ -15,6 +17,7 @@ AFRAME.registerComponent('connecting-line', {
     init() {
         this.startVector = new THREE.Vector3()
         this.endVector = new THREE.Vector3()
+        this.lineVector = new THREE.Vector3()
     },
 
     update() {
@@ -33,10 +36,55 @@ AFRAME.registerComponent('connecting-line', {
 
     // Position is updated on a tick() to accommodate movement of entities, which may
     // not be in the object hierarchy above the entity that the line is configured on.
+    
+    adjustLength(start, end) {
+      const { lengthAdjustment } = this.data
+      const line = this.lineVector
+      
+      switch (lengthAdjustment) {
+        case "none":
+          return
+
+        case "scale":
+          const lengthFactor = this.data.lengthAdjustmentValue
+          if (!lengthFactor) return
+          line.subVectors(end, start)
+          const scaleExtension = 1 + ((lengthFactor - 1) / 2)
+          line.multiplyScalar(scaleExtension)
+          break
+
+        case "extend":
+          const extension = this.data.lengthAdjustmentValue
+          if (!extension) return
+          line.subVectors(end, start)
+          line.normalize()
+          line.multiplyScalar(-extension)
+          break
+
+        case "absolute":
+          const targetLength = this.data.lengthAdjustmentValue
+          if (!targetLength) return
+          line.subVectors(end, start)
+          const currentLength = line.length()
+          if (currentLength === 0) return
+          const absExtension = ((targetLength / currentLength) - 1) / 2
+          line.multiplyScalar(-absExtension)
+          break
+
+        default:
+          console.error("Unexpected value for lengthAdjustment: ", lengthAdjustment)
+          return
+      }
+
+      start.addVectors(start, line)
+      end.subVectors(end, line)
+    },
+    
     tick() {
 
         const start = this.startVector
         const end = this.endVector
+        const line = this.lineVector
 
         // transform start & end vectors to local space.
         start.copy(this.data.startOffset)
@@ -48,6 +96,8 @@ AFRAME.registerComponent('connecting-line', {
         this.data.end.object3D.updateMatrixWorld()
         this.data.end.object3D.localToWorld(end)
         this.el.object3D.worldToLocal(end)
+
+        this.adjustLength(start, end)
 
         this.el.setAttribute(`line__${this.attrName}`, 
                              `start: ${start.x} ${start.y} ${start.z};

--- a/components/connecting-line/package.json
+++ b/components/connecting-line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aframe-connecting-line",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Uses the A-Frame \"line\" component to draw a line between points on two entities.",
   "main": "index.js",
   "directories": {

--- a/components/connecting-line/test/length-factor.html
+++ b/components/connecting-line/test/length-factor.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html>
+  <head>
+      <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+      <script src="../index.js"></script>
+      <link rel="stylesheet" href="../../../../styles.css">
+  </head>
+  <body>
+    <div class="text-overlay">
+        <p>connecting-line: Test length adjustment parameters</p>
+        <p>We have adjustment by scale, extend (trim) & absolute.</p>
+        <p>Top-to-bottom we should end up at 0.5, 1 and 2 times the standard length (at the innermost position)</p>
+    </div>
+        <a class="code-link"
+        target="_blank"
+        href="https://github.com/diarmidmackenzie/aframe-components/blob/main/components/connecting-line/test/index.html">
+        view code
+    </a>
+    
+    <a-scene background="color:black">
+      <a-mixin id="animate-right"
+               animation="property:position;
+                          from: 0 0 0;
+                          to: 0.5 0 0;
+                          dir: alternate;
+                          loop: true">
+      </a-mixin>
+      <a-mixin id="animate-left"
+               animation="property:position;
+                          from: 0 0 0;
+                          to: -0.5 0 0;
+                          dir: alternate;
+                          loop: true">
+      </a-mixin>
+      <a-entity camera look-controls wasd-controls position="0 1.6 0"></a-entity>
+
+      <a-entity id="container" position = "0 1 -4">
+
+        <a-entity position="-5 0 0">
+          <a-text color="white" value="Scale" align="center" position="0 1.5 0"></a-text>
+          <a-entity mixin="animate-left">
+            <a-sphere id="point11" position="-1 1 0" radius="0.1" color="#EF2D5E"></a-sphere>
+            <a-sphere id="point13" position="-1 0 0" radius="0.1" color="#EF2D5E"></a-sphere>
+            <a-sphere id="point15" position="-1 -1 0" radius="0.1" color="#EF2D5E"></a-sphere>
+          </a-entity>
+          <a-entity mixin="animate-right">
+            <a-sphere id="point12" position="1 1 0" radius="0.1" color="#EF2D5E"></a-sphere>
+            <a-sphere id="point14" position="1 0 0" radius="0.1" color="#EF2D5E"></a-sphere>
+            <a-sphere id="point16" position="1 -1 0" radius="0.1" color="#EF2D5E"></a-sphere>
+          </a-entity>
+        </a-entity>
+
+        <a-text color="white" value="Extend (Trim)" align="center" position="0 1.5 0"></a-text>
+        <a-entity mixin="animate-left">
+          <a-sphere id="point21" position="-1 0.9 0" radius="0.1" color="#EF2D5E"></a-sphere>
+          <a-sphere id="point23" position="-1 -0.1 0" radius="0.1" color="#EF2D5E"></a-sphere>
+          <a-sphere id="point25" position="-1 -1.1 0" radius="0.1" color="#EF2D5E"></a-sphere>
+        </a-entity>
+        
+        <a-entity mixin="animate-right">
+          <a-sphere id="point22" position="1 0.9 0" radius="0.1" color="#EF2D5E"></a-sphere>
+          <a-sphere id="point24" position="1 -0.1 0" radius="0.1" color="#EF2D5E"></a-sphere>
+          <a-sphere id="point26" position="1 -1.1 0" radius="0.1" color="#EF2D5E"></a-sphere>
+        </a-entity>
+
+        <a-entity position="5 0 0">
+          <a-text color="white" value="Absolute" align="center" position="0 1.5 0"></a-text>
+          <a-entity mixin="animate-left">
+            <a-sphere id="point31" position="-1 1 0" radius="0.1" color="#EF2D5E"></a-sphere>
+            <a-sphere id="point33" position="-1 0 0" radius="0.1" color="#EF2D5E"></a-sphere>
+            <a-sphere id="point35" position="-1 -1 0" radius="0.1" color="#EF2D5E"></a-sphere>
+          </a-entity>
+          
+          <a-entity mixin="animate-right">
+            <a-sphere id="point32" position="1 1 0" radius="0.1" color="#EF2D5E"></a-sphere>
+            <a-sphere id="point34" position="1 0 0" radius="0.1" color="#EF2D5E"></a-sphere>
+            <a-sphere id="point36" position="1 -1 0" radius="0.1" color="#EF2D5E"></a-sphere>
+          </a-entity>
+        </a-entity>
+      </a-entity>
+
+      <a-entity connecting-line__11="start:#point11;
+                                    end:#point12;
+                                    color:red;
+                                    lengthAdjustment: scale;
+                                    lengthAdjustmentValue: 0.5"
+                connecting-line__12="start:#point13;
+                                    end:#point14;
+                                    color:yellow
+                                    lengthAdjustment: scale;
+                                    lengthAdjustmentValue: 1"
+                connecting-line__13="start:#point15;
+                                    end:#point16;
+                                    color:cyan;
+                                    lengthAdjustment: scale;
+                                    lengthAdjustmentValue: 2"
+                connecting-line__21="start:#point21;
+                                    end:#point22;
+                                    color:red;
+                                    lengthAdjustment: extend;
+                                    lengthAdjustmentValue: -0.5"
+                connecting-line__22="start:#point23;
+                                    end:#point24;
+                                    color:yellow
+                                    lengthAdjustment: extend;
+                                    lengthAdjustmentValue: 0"
+                connecting-line__23="start:#point25;
+                                    end:#point26;
+                                    color:cyan;
+                                    lengthAdjustment: extend;
+                                    lengthAdjustmentValue: 1"
+                connecting-line__31="start:#point31;
+                                    end:#point32;
+                                    color:red;
+                                    lengthAdjustment: absolute;
+                                    lengthAdjustmentValue: 1"
+                connecting-line__32="start:#point33;
+                                    end:#point34;
+                                    color:yellow
+                                    lengthAdjustment: absolute;
+                                    lengthAdjustmentValue: 2"
+                connecting-line__33="start:#point35;
+                                    end:#point36;
+                                    color:cyan;
+                                    lengthAdjustment: absolute;
+                                    lengthAdjustmentValue: 4">
+      </a-entity>
+    </a-scene>
+  </body>
+</html>


### PR DESCRIPTION
Add parameters to control length of a connecting line.

Can be adjusted by:
- scale (scale up/down by a specified amount)
- extend (extend - or trim - by a specified absolute amount)
- absolute (make the connecting line have a fixed absolute length).

