### PR TITLE
Fix stats collector for A-Frame 1.6.0+

### DIFF
--- a/component-usage/stats-collector.html
+++ b/component-usage/stats-collector.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-      <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+      <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
       <script src="../components/stats-panel/index.js"></script>
       <link rel="stylesheet" href="../styles.css">
       <script>

--- a/component-usage/stats-panel.html
+++ b/component-usage/stats-panel.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-      <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+      <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
       <script src="../components/stats-panel/index.js"></script>
       <link rel="stylesheet" href="../styles.css">
       <script>

--- a/components/stats-panel/index.js
+++ b/components/stats-panel/index.js
@@ -117,13 +117,15 @@ AFRAME.registerComponent('stats-row', {
       this.counterValues[property] = counterValue
     })
 
-    this.updateData = this.updateData.bind(this)
-    this.el.addEventListener(this.data.event, this.updateData)
+    this.updateStatsData = this.updateStatsData.bind(this)
+    this.el.addEventListener(this.data.event, this.updateStatsData)
 
     this.splitCache = {}
   },
 
-  updateData(e) {
+  updateStatsData(e) {
+
+    if (!this.data.properties) return
     
     this.data.properties.forEach((property) => {
       const split = this.splitDot(property);
@@ -201,7 +203,7 @@ AFRAME.registerComponent('stats-collector', {
 
   statsReceived(e) {
 
-    this.updateData(e.detail)
+    this.updateStatsData(e.detail)
 
     this.counter++ 
     if (this.counter === this.data.outputFrequency) {
@@ -210,7 +212,7 @@ AFRAME.registerComponent('stats-collector', {
     }
   },
 
-  updateData(detail) {
+  updateStatsData(detail) {
 
     this.data.properties.forEach((property) => {
       let value = detail;

--- a/components/stats-panel/package.json
+++ b/components/stats-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aframe-stats-panel",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A-Frame statistics panel for additional statistics, in the style of A-Frame stats",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Since 1.6.0, a method called updateData clashes with an internal A-Frame method.

So use a different name.
https://github.com/aframevr/aframe/blob/6b8a8c3052b1c8b6d1ddbfc765fbe34893a1965c/src/core/component.js#L274

