### PR TITLE
[plug-socket] Revert this.worldSpaceObject.el=undefined change in remove

### DIFF
--- a/components/plug-socket/src/socket.js
+++ b/components/plug-socket/src/socket.js
@@ -47,7 +47,6 @@ AFRAME.registerComponent('socket', {
     this.el.removeEventListener('binding-failed', this.bindingFailed)
     this.el.removeEventListener('binding-success', this.bindingSuccess)
     this.removeFromSystem()
-    this.worldSpaceObject.el = undefined
   },
 
   findFabric() {


### PR DESCRIPTION
Revert this.worldSpaceObject.el=undefined change in remove that I did in #45, the reference is needed in cancelPeer called from another socket.
@diarmidmackenzie 