### PR TITLE
Add canonical repository.directory to all component package.json (fix npm README images)

### DIFF
--- a/components/anchored/package.json
+++ b/components/anchored/package.json
@@ -23,5 +23,10 @@
   "devDependencies": {
     "webpack": "^5.75.0",
     "webpack-cli": "^5.1.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/anchored"
   }
 }

--- a/components/ball-blaster/package.json
+++ b/components/ball-blaster/package.json
@@ -7,5 +7,10 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Diarmid Mackenzie",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/ball-blaster"
+  }
 }

--- a/components/bricks/package.json
+++ b/components/bricks/package.json
@@ -12,5 +12,10 @@
     "building"
   ],
   "author": "Diarmid Mackenzie",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/bricks"
+  }
 }

--- a/components/connecting-line/package.json
+++ b/components/connecting-line/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/diarmidmackenzie/aframe-components/tree/main/components/connecting-line"
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/connecting-line"
   },
   "keywords": [
     "A-Frame",

--- a/components/cursor-tracker/package.json
+++ b/components/cursor-tracker/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/diarmidmackenzie/aframe-components/tree/main/components/cursor-tracker"
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/cursor-tracker"
   },
   "keywords": [
     "A-Frame",

--- a/components/dat-gui/package.json
+++ b/components/dat-gui/package.json
@@ -24,5 +24,10 @@
   },
   "dependencies": {
     "dat.gui": "^0.7.9"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/dat-gui"
   }
 }

--- a/components/desktop-vr-controller/package.json
+++ b/components/desktop-vr-controller/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/diarmidmackenzie/aframe-components/tree/main/components/desktop-vr-controller"
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/desktop-vr-controller"
   },
   "keywords": [
     "A-Frame",

--- a/components/desktop-xr-hands/package.json
+++ b/components/desktop-xr-hands/package.json
@@ -29,5 +29,10 @@
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.15.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/desktop-xr-hands"
   }
 }

--- a/components/desktop-xr-plane/package.json
+++ b/components/desktop-xr-plane/package.json
@@ -11,5 +11,10 @@
     "A-Frame"
   ],
   "author": "Diarmid Mackenzie",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/desktop-xr-plane"
+  }
 }

--- a/components/dynamic-snap/package.json
+++ b/components/dynamic-snap/package.json
@@ -23,5 +23,10 @@
   "devDependencies": {
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/dynamic-snap"
   }
 }

--- a/components/frame-rate/package.json
+++ b/components/frame-rate/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git"
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/frame-rate"
   },
   "keywords": [
     "A-Frame",

--- a/components/graph/package.json
+++ b/components/graph/package.json
@@ -26,5 +26,10 @@
   "devDependencies": {
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/graph"
   }
 }

--- a/components/head-tracking/package.json
+++ b/components/head-tracking/package.json
@@ -20,5 +20,10 @@
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.15.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/head-tracking"
   }
 }

--- a/components/label/package.json
+++ b/components/label/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/diarmidmackenzie/aframe-components/tree/main/components/label"
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/label"
   },
   "keywords": [
     "A-Frame",

--- a/components/laser-manipulation/package.json
+++ b/components/laser-manipulation/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/diarmidmackenzie/aframe-components/tree/main/components/laser-manipulation"
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/laser-manipulation"
   },
   "keywords": [
     "A-Frame",

--- a/components/mouse-manipulation/package.json
+++ b/components/mouse-manipulation/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/diarmidmackenzie/aframe-components/tree/main/components/mouse-manipulation"
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/mouse-manipulation"
   },
   "keywords": [
     "A-Frame",

--- a/components/object-parent/package.json
+++ b/components/object-parent/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/diarmidmackenzie/aframe-components/tree/main/components/object-parent"
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/object-parent"
   },
   "keywords": [
     "A-Frame",

--- a/components/plug-socket/package.json
+++ b/components/plug-socket/package.json
@@ -26,5 +26,10 @@
     "qunit": "^2.19.4",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/plug-socket"
   }
 }

--- a/components/polygon-wireframe/package.json
+++ b/components/polygon-wireframe/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/diarmidmackenzie/aframe-components/tree/main/components/polygon-wireframe"
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/polygon-wireframe"
   },
   "keywords": [
     "A-Frame",

--- a/components/raycast-target/package.json
+++ b/components/raycast-target/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/diarmidmackenzie/aframe-components/tree/main/components/raycast-target"
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/raycast-target"
   },
   "keywords": [
     "A-Frame",

--- a/components/raycaster-thresholds/package.json
+++ b/components/raycaster-thresholds/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/diarmidmackenzie/aframe-components/tree/main/components/raycaster-thresholds"
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/raycaster-thresholds"
   },
   "keywords": [
     "A-Frame",

--- a/components/screen-position/package.json
+++ b/components/screen-position/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/diarmidmackenzie/aframe-components/tree/main/components/screen-position"
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/screen-position"
   },
   "keywords": [
     "A-Frame",

--- a/components/stats-panel/package.json
+++ b/components/stats-panel/package.json
@@ -13,5 +13,10 @@
   ],
   "homepage": "https://diarmidmackenzie.github.io/aframe-components/components/stats-panel#readme",
   "author": "Diarmid Mackenzie",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/stats-panel"
+  }
 }

--- a/components/thumbstick-states/package.json
+++ b/components/thumbstick-states/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/diarmidmackenzie/aframe-components/tree/main/components/thumbstick-states"
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/thumbstick-states"
   },
   "keywords": [
     "A-Frame",

--- a/components/xr-room-physics/package.json
+++ b/components/xr-room-physics/package.json
@@ -29,5 +29,10 @@
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.15.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
+    "directory": "components/xr-room-physics"
   }
 }


### PR DESCRIPTION
## Why

npm only rewrites relative README image URLs to the git source when it can locate that source via the `repository` field. For a monorepo package published from a subdirectory, the `directory` subfield is required so npm resolves images against the correct subpath.

Concretely: `aframe-dat-gui`'s README image 404s on npmjs.com because the package had no `repository` field, whereas `aframe-instanced-mesh` (a standalone repo with a `repository` field) renders fine.

## What

Normalize the `repository` field across **all 25** component packages to:

```json
"repository": {
  "type": "git",
  "url": "git+https://github.com/diarmidmackenzie/aframe-components.git",
  "directory": "components/<name>"
}
```

- **12** packages were missing `repository` entirely (incl. `aframe-dat-gui`).
- **13** had it but in a non-canonical form: malformed `/tree/main/...` URLs (not valid git URLs) or a bare repo URL with no `directory`.

Metadata-only change. This is "Option A" — relies on npm honoring `directory` for image rewriting. If images still 404 after republish, the fallback is "Option B": absolute `raw.githubusercontent.com` URLs in the READMEs.

> Note: the field only takes effect on npmjs.com after each package is **republished** at a new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)